### PR TITLE
Update workflows for GHCR

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -313,7 +313,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        docker pull mobiusmdm/wix:latest &
+        docker pull ghcr.io/notawar/wix:latest &
         npm install -g mobiuscli
         mobiuscli config set --address ${{ needs.gen.outputs.address }} --token ${{ needs.login.outputs.token }}
 

--- a/.github/workflows/release-mobiuscli-docker-deps.yaml
+++ b/.github/workflows/release-mobiuscli-docker-deps.yaml
@@ -1,9 +1,10 @@
-# Builds and releases to production the mobiusmdm/bomutils:latest and mobiusmdm/wix:latest
-# docker images, which are the docker image dependencies of the mobiuscli command.
+# Builds and releases to production the ghcr.io/notawar/bomutils:latest and
+# ghcr.io/notawar/wix:latest Docker images, which are the docker image
+# dependencies of the mobiuscli command.
 #
 # This is separate from Mobius releases because we only release
-# mobiusmdm/bomutils and mobiusmdm/wix only if we add new dependencies
-# or for security updates.
+# ghcr.io/notawar/bomutils and ghcr.io/notawar/wix only if we add new
+# dependencies or for security updates.
 name: Release mobiuscli docker dependencies
 
 on:
@@ -27,7 +28,6 @@ permissions:
 jobs:
   push_latest:
     runs-on: ubuntu-latest
-    environment: Docker Hub
     permissions:
       contents: write
     steps:
@@ -72,8 +72,8 @@ jobs:
       # Now push to production
       #
 
-      - name: Push mobiusmdm/bomutils to docker hub
-        run: docker push mobiusmdm/bomutils:latest
+      - name: Push ghcr.io/notawar/bomutils
+        run: docker push ghcr.io/notawar/bomutils:latest
 
-      - name: Push mobiusmdm/wix to docker hub
-        run: docker push mobiusmdm/wix:latest
+      - name: Push ghcr.io/notawar/wix
+        run: docker push ghcr.io/notawar/wix:latest


### PR DESCRIPTION
## Summary
- push Docker build artifacts to GitHub Packages instead of Docker Hub
- update integration workflow to pull images from GHCR

## Testing
- `go test ./...` *(fails: no required module provides package github.com/notawar/mobius/pkg/mobiusdbase)*

------
https://chatgpt.com/codex/tasks/task_e_6866ee30cac4832ea950eda7ab3271f4