### PR TITLE
Fix node setup caching

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -35,6 +35,7 @@ jobs:
       with:
         node-version: '20'
         cache: 'yarn'
+        cache-dependency-path: '**/yarn.lock'
     
     - name: Run backend tests
       if: matrix.component == 'backend'


### PR DESCRIPTION
## Summary
- fix Node workflow cache path for yarn

## Testing
- `actionlint .github/workflows/build-and-deploy.yml`

------
https://chatgpt.com/codex/tasks/task_e_68670e673594832e8052a583f3051edd