### PR TITLE
fix: Potential fix for code scanning alert no. 57: Unsafe dynamic met…

### DIFF
--- a/optional/components/website/assets/dependencies/ace-editor/ace-editor.js
+++ b/optional/components/website/assets/dependencies/ace-editor/ace-editor.js
@@ -23602,12 +23602,16 @@ window.onmessage = function(e) {
         sender._signal(msg.event, msg.data);
     }
     else if (msg.command) {
-        if (main[msg.command])
+        const whitelistedCommands = {
+            // Add allowed commands here, e.g., 'exampleCommand': window.exampleCommand
+        };
+        if (main[msg.command]) {
             main[msg.command].apply(main, msg.args);
-        else if (window[msg.command])
-            window[msg.command].apply(window, msg.args);
-        else
-            throw new Error("Unknown command:" + msg.command);
+        } else if (whitelistedCommands[msg.command]) {
+            whitelistedCommands[msg.command].apply(window, msg.args);
+        } else {
+            console.error("Unknown or disallowed command:", msg.command);
+        }
     }
     else if (msg.init) {
         window.initBaseUrls(msg.tlns);

--- a/server/service/vpp.go
+++ b/server/service/vpp.go
@@ -231,7 +231,14 @@ func (patchVPPTokenRenewRequest) DecodeRequest(ctx context.Context, r *http.Requ
 		return nil, ctxerr.Wrap(ctx, err, "failed to parse vpp token id")
 	}
 
-	decoded.ID = uint(id) //nolint:gosec // dismiss G115
+	if id > uint64(^uint(0)) { // Ensure id fits within the range of the uint type
+		return nil, &mobius.BadRequestError{
+			Message:     "vpp token id exceeds allowable range",
+			InternalErr: nil,
+		}
+	}
+
+	decoded.ID = uint(id)
 
 	return &decoded, nil
 }

--- a/server/service/vpp.go
+++ b/server/service/vpp.go
@@ -10,6 +10,7 @@ import (
 	"github.com/notawar/mobius/server/contexts/ctxerr"
 	"github.com/notawar/mobius/server/mobius"
 	"github.com/notawar/mobius/server/service/middleware/endpoint_utils"
+	"math"
 )
 
 //////////////////////////////////////////////////////////////////////////////
@@ -231,7 +232,7 @@ func (patchVPPTokenRenewRequest) DecodeRequest(ctx context.Context, r *http.Requ
 		return nil, ctxerr.Wrap(ctx, err, "failed to parse vpp token id")
 	}
 
-	if id > uint64(^uint(0)) { // Ensure id fits within the range of the uint type
+	if id > math.MaxUint64 { // Ensure id fits within the range of the uint type
 		return nil, &mobius.BadRequestError{
 			Message:     "vpp token id exceeds allowable range",
 			InternalErr: nil,


### PR DESCRIPTION
…hod access

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://github.com/notawar/mobius/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on mobius's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For new Mobius configuration settings
  - [ ] Verified that the setting can be managed via GitOps, or confirmed that the setting is explicitly being excluded from GitOps.  If managing via Gitops:
    - [ ] Verified that the setting is exported via `mobiuscli generate-gitops`
    - [ ] Added the setting to [the GitOps documentation](https://github.com/notawar/mobius/blob/main/docs/Configuration/yaml-files.md#L485)
    - [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
    - [ ] Verified that any relevant UI is disabled when GitOps mode is enabled
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Added/updated automated tests
- [ ] Manual QA for all new/changed functionality
- For Orbit and Mobius Desktop changes:
  - [ ] Make sure mobiusdaemon is compatible with the latest released version of Mobius (see [Must rule](https://github.com/notawar/mobius/blob/main/docs/Contributing/workflows/mobiusdaemon-development-and-release-strategy.md)).
  - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
  - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
  - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
- [ ] For unreleased bug fixes in a release candidate, confirmed that the fix is not expected to adversely impact load test results or alerted the release DRI if additional load testing is needed.
