### PR TITLE
Fix puppet workflow path check

### DIFF
--- a/.github/workflows/test-puppet.yml
+++ b/.github/workflows/test-puppet.yml
@@ -5,9 +5,12 @@ on:
     branches:
       - main
       - patch-*
+    paths:
+      - 'tools/puppet/mobiusmdm/**'
+      - '.github/workflows/test-puppet.yml'
   pull_request:
     paths:
-      - 'ee/tools/puppet/mobiusmdm/**'
+      - 'tools/puppet/mobiusmdm/**'
       - '.github/workflows/test-puppet.yml'
   workflow_dispatch: # Manual
 
@@ -26,6 +29,7 @@ permissions:
 
 jobs:
   test-puppet:
+    if: ${{ hashFiles('tools/puppet/mobiusmdm/**') != '' }}
     runs-on: macos-latest
     steps:
      


### PR DESCRIPTION
## Summary
- fix test-puppet workflow to only run when `tools/puppet/mobiusmdm` exists
- add path filters so the workflow only triggers when puppet files or the workflow change

## Testing
- `npm test` *(fails: `jest: not found`)*
- `npm install` *(fails: dependency resolution error)*
- `go test ./...` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686712edeff8832eb806fe185d86b039