### PR TITLE
Fix Tooltip tests and help text

### DIFF
--- a/frontend/components/LastUpdatedHostCount/LastUpdatedHostCount.tests.tsx
+++ b/frontend/components/LastUpdatedHostCount/LastUpdatedHostCount.tests.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
 
 import LastUpdatedHostCount from ".";
 
@@ -28,7 +29,9 @@ describe("Last updated host count", () => {
   it("renders tooltip on hover", async () => {
     render(<LastUpdatedHostCount hostCount={0} />);
 
-    await fireEvent.mouseEnter(screen.getByText("Updated never"));
+    await act(async () => {
+      fireEvent.mouseEnter(screen.getByText("Updated never"));
+    });
 
     expect(
       screen.getByText(/last time host data was updated/i)

--- a/frontend/components/StatusIndicator/StatusIndicator.tests.tsx
+++ b/frontend/components/StatusIndicator/StatusIndicator.tests.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
 
 import StatusIndicator from "./StatusIndicator";
 
@@ -16,7 +17,9 @@ describe("Status indicator", () => {
       <StatusIndicator value="online" tooltip={{ tooltipText: TOOLTIP_TEXT }} />
     );
 
-    await fireEvent.mouseEnter(screen.getByText("Online"));
+    await act(async () => {
+      fireEvent.mouseEnter(screen.getByText("Online"));
+    });
 
     expect(screen.getByText(TOOLTIP_TEXT)).toBeInTheDocument();
   });

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tests.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tests.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import userEvent from "@testing-library/user-event";
 import { screen } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
 import { createCustomRenderer, createMockRouter } from "test/test-utils";
 import SoftwareNameCell from "./SoftwareNameCell";
 
@@ -39,7 +40,9 @@ describe("SoftwareNameCell icon rendering", () => {
     const render = createCustomRenderer();
     render(<SoftwareNameCell {...defaultProps} hasInstaller />);
     const icon = screen.getByTestId("install-icon");
-    await userEvent.hover(icon);
+    await act(async () => {
+      await userEvent.hover(icon);
+    });
     expect(
       await screen.findByText(
         /Software can be installed on the host details page/i
@@ -57,7 +60,9 @@ describe("SoftwareNameCell icon rendering", () => {
       />
     );
     const icon = screen.getByTestId("install-icon");
-    await userEvent.hover(icon);
+    await act(async () => {
+      await userEvent.hover(icon);
+    });
     expect(await screen.findByText(/on the Library tab/i)).toBeInTheDocument();
   });
 
@@ -78,7 +83,9 @@ describe("SoftwareNameCell icon rendering", () => {
     const render = createCustomRenderer();
     render(<SoftwareNameCell {...defaultProps} hasInstaller isSelfService />);
     const icon = screen.getByTestId("user-icon");
-    await userEvent.hover(icon);
+    await act(async () => {
+      await userEvent.hover(icon);
+    });
     expect(
       await screen.findByText(/End users can install from/i)
     ).toBeInTheDocument();
@@ -95,7 +102,9 @@ describe("SoftwareNameCell icon rendering", () => {
       />
     );
     const icon = screen.getByTestId("user-icon");
-    await userEvent.hover(icon);
+    await act(async () => {
+      await userEvent.hover(icon);
+    });
     expect(
       await screen.findByText(/End users can install from/i)
     ).toBeInTheDocument();
@@ -112,7 +121,9 @@ describe("SoftwareNameCell icon rendering", () => {
       />
     );
     const icon = screen.getByTestId("user-icon");
-    await userEvent.hover(icon);
+    await act(async () => {
+      await userEvent.hover(icon);
+    });
     expect(
       await screen.findByText(/End users can install from/i)
     ).toBeInTheDocument();
@@ -129,7 +140,9 @@ describe("SoftwareNameCell icon rendering", () => {
       />
     );
     const icon = screen.getByTestId("refresh-icon");
-    await userEvent.hover(icon);
+    await act(async () => {
+      await userEvent.hover(icon);
+    });
     expect(
       await screen.findByText(/2 policies trigger install./i)
     ).toBeInTheDocument();
@@ -146,7 +159,9 @@ describe("SoftwareNameCell icon rendering", () => {
       />
     );
     const icon = screen.getByTestId("refresh-icon");
-    await userEvent.hover(icon);
+    await act(async () => {
+      await userEvent.hover(icon);
+    });
     expect(
       await screen.findByText(/3 policies trigger install./i)
     ).toBeInTheDocument();
@@ -163,7 +178,9 @@ describe("SoftwareNameCell icon rendering", () => {
       />
     );
     const icon = screen.getByTestId("refresh-icon");
-    await userEvent.hover(icon);
+    await act(async () => {
+      await userEvent.hover(icon);
+    });
     expect(
       await screen.findByText(/A policy triggers install./i)
     ).toBeInTheDocument();
@@ -181,7 +198,9 @@ describe("SoftwareNameCell icon rendering", () => {
       />
     );
     const icon = screen.getByTestId("automatic-self-service-icon");
-    await userEvent.hover(icon);
+    await act(async () => {
+      await userEvent.hover(icon);
+    });
     expect(
       await screen.findByText(/2 policies trigger install./i)
     ).toBeInTheDocument();
@@ -202,7 +221,9 @@ describe("SoftwareNameCell icon rendering", () => {
       />
     );
     const icon = screen.getByTestId("automatic-self-service-icon");
-    await userEvent.hover(icon);
+    await act(async () => {
+      await userEvent.hover(icon);
+    });
     expect(
       await screen.findByText(/2 policies trigger install./i)
     ).toBeInTheDocument();
@@ -223,7 +244,9 @@ describe("SoftwareNameCell icon rendering", () => {
       />
     );
     const icon = screen.getByTestId("automatic-self-service-icon");
-    await userEvent.hover(icon);
+    await act(async () => {
+      await userEvent.hover(icon);
+    });
     expect(
       await screen.findByText(/2 policies trigger install./i)
     ).toBeInTheDocument();

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tests.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tests.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import userEvent from "@testing-library/user-event";
 import { render, screen } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
 import TooltipWrapper from "./TooltipWrapper";
 
 describe("TooltipWrapper", () => {
@@ -13,7 +14,9 @@ describe("TooltipWrapper", () => {
     );
 
     const trigger = screen.getByText("Hover me");
-    userEvent.hover(trigger);
+    await act(async () => {
+      await userEvent.hover(trigger);
+    });
 
     // Wait for tooltip content to appear in the DOM
     expect(await screen.findByText("Tooltip text")).toBeInTheDocument();

--- a/frontend/components/forms/RegistrationForm/MobiusDetails/MobiusDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/MobiusDetails/MobiusDetails.jsx
@@ -44,11 +44,11 @@ class MobiusDetails extends Component {
           {...fields.server_url}
           label="Mobius web address"
           tabIndex={tabIndex}
-          helpText={[
-            "Don’t include ",
-            <code key="helpText">/latest</code>,
-            " or any other path.",
-          ]}
+          helpText={
+            <>
+              Don’t include <code>/latest</code> or any other path.
+            </>
+          }
           ref={(input) => {
             this.firstInput = input;
           }}

--- a/frontend/pages/DashboardPage/cards/HostCountCard/HostCountCard.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/HostCountCard/HostCountCard.tests.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { fireEvent, render, screen } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
 import paths from "router/paths";
 import HostCountCard from "./HostCountCard";
 
@@ -53,7 +54,9 @@ describe("HostCountCard - component", () => {
       />
     );
 
-    await fireEvent.mouseEnter(screen.getByText("Windows hosts"));
+    await act(async () => {
+      fireEvent.mouseEnter(screen.getByText("Windows hosts"));
+    });
 
     expect(screen.getByText("Hosts on any Windows device")).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- fix MobiusDetails help text prop type
- wrap hover events in `act()` in various tooltip tests
- ensure TooltipWrapper test hover wrapped in `act`

## Testing
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686717a1d504832e80f9f7a4287c7ee6