### PR TITLE
Align Node versions in workflows

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -33,7 +33,7 @@ jobs:
       if: matrix.component == 'frontend'
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '24.x'
         cache: 'yarn'
         cache-dependency-path: '**/yarn.lock'
     

--- a/.github/workflows/test-bulk-operations-dashboard-changes.yml
+++ b/.github/workflows/test-bulk-operations-dashboard-changes.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [24.x]
 
     steps:
      

--- a/.github/workflows/test-vulnerability-dashboard-changes.yml
+++ b/.github/workflows/test-vulnerability-dashboard-changes.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [24.x]
 
     steps:
      

--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
 
     steps:
  

--- a/optional/components/enterprise-workflows/deploy-mobius-website.yml
+++ b/optional/components/enterprise-workflows/deploy-mobius-website.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
 
     steps:
      

--- a/optional/components/enterprise-workflows/deploy-vulnerability-dashboard.yml
+++ b/optional/components/enterprise-workflows/deploy-vulnerability-dashboard.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [24.x]
 
     steps:
      

--- a/optional/components/website/package.json
+++ b/optional/components/website/package.json
@@ -46,6 +46,6 @@
     "url": "git://github.com/notawar/mobiusmdm-com.git"
   },
   "engines": {
-    "node": "^24.3"
+    "node": ">=24.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "The premier osquery mobius manager.",
   "engines": {
-    "node": ">=20.18.1",
-    "yarn": ">=1.22.21"
+    "node": ">=24.3.0",
+    "yarn": ">=1.22.22"
   },
   "private": true,
   "scripts": {
@@ -185,5 +185,5 @@
     "defaults"
   ],
   "license": "SEE LICENSE IN ./LICENSE",
-  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
## Summary
- update Node requirements to 24.x in various GitHub Actions
- bump engines in package files to require Node 24.3.0 and Yarn 1.22.22
- use Node 24.x range consistently in build-and-deploy workflow

## Testing
- `go test ./...` *(failed: interrupt)*
- `yarn test` *(failed: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686723b4e484832e86defdd4879b1408