### PR TITLE
Potential fix for code scanning alert no. 175: Disabled TLS certificate check

### DIFF
--- a/mobius-cli/cmd/mobiuscli/mobiuscli/preview.go
+++ b/mobius-cli/cmd/mobiuscli/mobiuscli/preview.go
@@ -544,7 +544,7 @@ func waitStartup() error {
 	retryStrategy := backoff.NewExponentialBackOff()
 	retryStrategy.MaxInterval = 1 * time.Second
 
-	client := mobiushttp.NewClient(mobiushttp.WithTLSClientConfig(&tls.Config{InsecureSkipVerify: true}))
+	client := mobiushttp.NewClient()
 
 	if err := backoff.Retry(
 		func() error {


### PR DESCRIPTION
Potential fix for [https://github.com/NotAwar/Mobius/security/code-scanning/175](https://github.com/NotAwar/Mobius/security/code-scanning/175)

To fix the issue, remove `InsecureSkipVerify: true` from the TLS client config in the call to `mobiushttp.NewClient` in `waitStartup()`. Instead, use the default verification.  
- Change line 547 to either create a client with a default TLS config (where `InsecureSkipVerify` is `false` by default), or omit the override entirely if verification is the default behavior.
- This depends on how `mobiushttp.NewClient` works, but generally, passing no option, or `WithTLSClientConfig(nil)` (or omitting the config) is recommended.
- No other logic needs to be changed in the snippet, as all the certificate validation is handled by Go’s standard library.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
