### PR TITLE
Potential fix for code scanning alert no. 174: Uncontrolled data used in path expression

### DIFF
--- a/mobius-server/server/mdm/nanomdm/storage/file/file.go
+++ b/mobius-server/server/mdm/nanomdm/storage/file/file.go
@@ -55,7 +55,21 @@ type enrollment struct {
 	fs *FileStorage
 }
 
+// isSafePathComponent checks that the input is a safe single path component.
+func isSafePathComponent(s string) bool {
+	if s == "" ||
+		strings.Contains(s, "/") ||
+		strings.Contains(s, "\\") ||
+		strings.Contains(s, "..") {
+		return false
+	}
+	return true
+}
+
 func (s *FileStorage) newEnrollment(id string) *enrollment {
+	if !isSafePathComponent(id) {
+		return nil
+	}
 	return &enrollment{fs: s, id: id}
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/NotAwar/Mobius/security/code-scanning/174](https://github.com/NotAwar/Mobius/security/code-scanning/174)

To fix this issue, we must validate all user-controlled data before it is used to construct file or directory paths. Specifically:
- Ensure that `id` (enrollment identifier) and `uuid` (command UUID) do not contain any path separators (`/`, `\`), periods (`..`), or are absolute paths.
- The simplest and safest solution is to check for the presence of `/`, `\`, or `..` in these inputs, and reject any input that contains these sequences.
- Implement two helper functions: `isSafePathComponent(s string) bool` that checks that its argument is a valid single path component (no `/`, `\`, `..`), and `validateIDs(ids []string) error` to check all IDs.
- Integrate these checks at the point where user-supplied data is used (preferably as close to the initial entry as possible, e.g., in `EnqueueCommand` and `newEnrollment`).
- If validation fails, return an error and do not touch the filesystem.

Required changes:
- Add the helper function(s) to mobius-server/server/mdm/nanomdm/storage/file/file.go.
- Update `newEnrollment(id string)` in file.go and uses of command UUIDs in queue.go to validate inputs.
- Where appropriate, propagate errors.
- No external dependencies are needed; use Go's standard library string checks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
