### PR TITLE
Potential fix for code scanning alert no. 141: Unused variable, import, function or class

### DIFF
--- a/mobius-web/src/lib/Layout.test.ts
+++ b/mobius-web/src/lib/Layout.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 // import { render, screen } from '@testing-library/svelte';
 // import Layout from '$lib/Layout.svelte';
 


### PR DESCRIPTION
Potential fix for [https://github.com/NotAwar/Mobius/security/code-scanning/141](https://github.com/NotAwar/Mobius/security/code-scanning/141)

The fix is to remove the unused import `beforeEach` from the import statement on line 1. Only the named imports that are actually used (`describe`, `it`, `expect`, `vi`) should remain. No other code or imports need to be edited, as there is no use of `beforeEach` in the shown code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
